### PR TITLE
Add minimal pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "numpy"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
This allows build-time dependencies (setuptools, numpy) to be specified so that pip (or another build frontend) knows to install them.